### PR TITLE
Correct missing / in log path for AWS dd benchmark

### DIFF
--- a/aws/disk/dd/lambda_function.py
+++ b/aws/disk/dd/lambda_function.py
@@ -23,12 +23,12 @@ def lambda_handler(event, context):
     bs = 'bs='+event['bs']
     count = 'count='+event['count']
 
-    out_fd = open(tmp + 'io_write_logs', 'w')
+    out_fd = open(tmp + '/io_write_logs', 'w')
     dd = subprocess.Popen(['dd', 'if=/dev/zero', 'of=/tmp/out', bs, count], stderr=out_fd)
     dd.communicate()
     
     subprocess.check_output(['ls', '-alh', tmp])
 
-    with open(tmp + 'io_write_logs') as logs:
+    with open(tmp + '/io_write_logs') as logs:
         result = str(logs.readlines()[2]).replace('\n', '')
         return result


### PR DESCRIPTION
Received an error while testing `dd` in AWS:

`"errorMessage": "[Errno 30] Read-only file system: '/tmpio_write_logs'",`

I noticed that a `/` character was removed from the log path in DD as part of a refactoring. Re-added the `/` character so that the logs path correctly resolves to `/tmp/io_write_logs`.