### PR TITLE
Google benchmarks minor fixes

### DIFF
--- a/google/cpu-memory/chameleon/main.py
+++ b/google/cpu-memory/chameleon/main.py
@@ -21,8 +21,6 @@ def function_handler(request):
     num_of_rows = request_json['num_of_rows']
     num_of_cols = request_json['num_of_cols']
 
-    message = generate(length_of_message)
-
     # 128-bit key (16 bytes)
     KEY = b'\xa1\xf6%\x8c\x87}_\xcd\x89dHE8\xbf\xc9,'
 

--- a/google/cpu-memory/chameleon/requirements.txt
+++ b/google/cpu-memory/chameleon/requirements.txt
@@ -1,1 +1,2 @@
 chameleon
+six

--- a/google/cpu-memory/linpack/main.py
+++ b/google/cpu-memory/linpack/main.py
@@ -1,4 +1,4 @@
-from numpy import matrix, array, linalg, random, amax, asscalar
+from numpy import matrix, array, linalg, random, amax
 from time import time
 
 def linpack(N):

--- a/google/disk/gzip_compression/main.py
+++ b/google/disk/gzip_compression/main.py
@@ -13,7 +13,7 @@ def function_handler(request):
         f.write(os.urandom(file_size * 1024 * 1024))
     disk_latency = time() - start
 
-    with open(file_write_path) as f:
+    with open(file_write_path, 'rb') as f:
         start = time()
         with gzip.open('/tmp/result.gz', 'wb') as gz:
             gz.writelines(f)


### PR DESCRIPTION
Minor fixes in Google benchmarks:
- Updated requirements in google - chameleon benchmark
- Removed redundant line in chameleon that broke benchmark
- Fixed error with permissions in gzip_compression
- Removed deprecated import from linpack